### PR TITLE
SPM-31 fix: Ensure husky preparation does not fail the install process

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clean": "turbo clean",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "preinstall": "npx only-allow npm",
-    "prepare": "husky"
+    "prepare": "husky || true"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.13.0",


### PR DESCRIPTION
Closes #31 

This pull request introduces a small change to the `package.json` file to make the `prepare` script more robust. The script now allows the installation process to continue even if Husky fails to set up, which can help prevent installation errors in some environments.