### PR TITLE
SPM-17: Password hashing too weak

### DIFF
--- a/apps/backend-rest/src/auth/auth.service.ts
+++ b/apps/backend-rest/src/auth/auth.service.ts
@@ -52,7 +52,7 @@ export class AuthService {
       throw new ConflictException("User with this email already exists");
     }
 
-    const hashedPassword = await bcrypt.hash(registerDto.password, 10);
+    const hashedPassword = await bcrypt.hash(registerDto.password, 12);
 
     const user = await this.usersService.create({
       email: registerDto.email,

--- a/apps/backend-rest/src/users/users.service.ts
+++ b/apps/backend-rest/src/users/users.service.ts
@@ -52,7 +52,7 @@ export class UsersService {
     const data: any = { ...rest };
 
     if (password) {
-      const hashedPassword = await bcrypt.hash(password, 10);
+      const hashedPassword = await bcrypt.hash(password, 12);
       data.password = hashedPassword;
     }
 


### PR DESCRIPTION
Closes #17  
This pull request increases the security of password hashing in the authentication and user creation flows by updating the bcrypt salt rounds from 10 to 12 in both the `AuthService` and `UsersService`. This makes it more computationally expensive to brute-force passwords, improving overall application security.

Password hashing security improvements:

* Increased bcrypt salt rounds from 10 to 12 in the `register` method of `AuthService` (`apps/backend-rest/src/auth/auth.service.ts`).
* Increased bcrypt salt rounds from 10 to 12 in the `create` method of `UsersService` (`apps/backend-rest/src/users/users.service.ts`).