### PR TITLE
SPM-60 feat: Implement `/ping` endpoint & tests

### DIFF
--- a/apps/backend-rest/src/app.module.ts
+++ b/apps/backend-rest/src/app.module.ts
@@ -8,6 +8,7 @@ import { CommonModule } from "./common/common.module";
 import { DomainsModule } from "./domains/domains.module";
 import { EffectsModule } from "./effects/effects.module";
 import { EssencesModule } from "./essences/essences.module";
+import { HealthModule } from "./health/health.module";
 import { InventoriesModule } from "./inventories/inventories.module";
 import { PrismaModule } from "./prisma/prisma.module";
 import { SettingsModule } from "./settings/settings.module";
@@ -19,6 +20,7 @@ import { SettingsModule } from "./settings/settings.module";
     }),
     CommonModule,
     PrismaModule,
+    HealthModule,
     AuthModule,
     CharactersModule,
     AttributesModule,

--- a/apps/backend-rest/src/health/health.controller.spec.ts
+++ b/apps/backend-rest/src/health/health.controller.spec.ts
@@ -1,0 +1,53 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { HealthController } from "./health.controller";
+import { HealthService } from "./health.service";
+
+describe("HealthController", () => {
+  let controller: HealthController;
+  let service: HealthService;
+
+  const mockHealthService = {
+    ping: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [HealthController],
+      providers: [
+        {
+          provide: HealthService,
+          useValue: mockHealthService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<HealthController>(HealthController);
+    service = module.get<HealthService>(HealthService);
+
+    jest.clearAllMocks();
+  });
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe("ping", () => {
+    it("should return status ok", () => {
+      const expectedResponse = { status: "ok" };
+      mockHealthService.ping.mockReturnValue(expectedResponse);
+
+      const result = controller.ping();
+
+      expect(result).toEqual(expectedResponse);
+      expect(service.ping).toHaveBeenCalledTimes(1);
+    });
+
+    it("should call health service ping method", () => {
+      mockHealthService.ping.mockReturnValue({ status: "ok" });
+
+      controller.ping();
+
+      expect(service.ping).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/backend-rest/src/health/health.controller.ts
+++ b/apps/backend-rest/src/health/health.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Get } from "@nestjs/common";
+import { ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
+import { HealthService } from "./health.service";
+
+@ApiTags("health")
+@Controller()
+export class HealthController {
+  constructor(private readonly healthService: HealthService) {}
+
+  @Get("ping")
+  @ApiOperation({ summary: "Health check endpoint" })
+  @ApiResponse({
+    status: 200,
+    description: "API is healthy and responding",
+    schema: {
+      type: "object",
+      properties: {
+        status: { type: "string", example: "ok" },
+      },
+    },
+  })
+  ping() {
+    return this.healthService.ping();
+  }
+}

--- a/apps/backend-rest/src/health/health.module.ts
+++ b/apps/backend-rest/src/health/health.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { HealthController } from "./health.controller";
+import { HealthService } from "./health.service";
+
+@Module({
+  controllers: [HealthController],
+  providers: [HealthService],
+})
+export class HealthModule {}

--- a/apps/backend-rest/src/health/health.service.spec.ts
+++ b/apps/backend-rest/src/health/health.service.spec.ts
@@ -1,0 +1,34 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { HealthService } from "./health.service";
+
+describe("HealthService", () => {
+  let service: HealthService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [HealthService],
+    }).compile();
+
+    service = module.get<HealthService>(HealthService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  describe("ping", () => {
+    it("should return status ok", () => {
+      const result = service.ping();
+
+      expect(result).toEqual({ status: "ok" });
+    });
+
+    it("should return consistent response", () => {
+      const result1 = service.ping();
+      const result2 = service.ping();
+
+      expect(result1).toEqual(result2);
+      expect(result1).toEqual({ status: "ok" });
+    });
+  });
+});

--- a/apps/backend-rest/src/health/health.service.ts
+++ b/apps/backend-rest/src/health/health.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class HealthService {
+  /**
+   * Returns a simple health status
+   * @returns Object with status "ok"
+   */
+  ping() {
+    return { status: "ok" };
+  }
+}


### PR DESCRIPTION
Closes #60 
This pull request introduces a new health check feature to the backend REST API by adding a dedicated `HealthModule`. This includes a controller, service, and corresponding tests to provide and verify a `/ping` endpoint that returns a simple health status response. The module is also integrated into the main application module.

**Health check feature implementation:**

* Added a new `HealthModule` with `HealthController` and `HealthService` to encapsulate health check logic. (`apps/backend-rest/src/health/health.module.ts`, `apps/backend-rest/src/health/health.controller.ts`, `apps/backend-rest/src/health/health.service.ts`) [[1]](diffhunk://#diff-ff790d75a6d84684f55b77b238871b18835f07024445a6ca73b00b999ea427daR1-R9) [[2]](diffhunk://#diff-6a6a92040a8d2e042377ca9198b8062c9f11a12ff9054ae12b37a7288355b165R1-R25) [[3]](diffhunk://#diff-2ca3c37f13a23d249704ab976dc8d82eacb57129595d51810a5578ffd16ea23bR1-R12)
* Implemented a `/ping` endpoint in `HealthController` that returns `{ status: "ok" }` for basic API health verification. (`apps/backend-rest/src/health/health.controller.ts`)
* Integrated the new `HealthModule` into the main application by updating imports and module dependencies in `app.module.ts`. (`apps/backend-rest/src/app.module.ts`) [[1]](diffhunk://#diff-e061f4b1114801405da97b38132b139f7da8ba9f7acd35ba81879eeec6bc2348R11) [[2]](diffhunk://#diff-e061f4b1114801405da97b38132b139f7da8ba9f7acd35ba81879eeec6bc2348R23)

**Testing:**

* Added unit tests for `HealthService` to ensure the `ping` method returns the expected response. (`apps/backend-rest/src/health/health.service.spec.ts`)
* Added unit tests for `HealthController` to verify endpoint behavior and service interaction. (`apps/backend-rest/src/health/health.controller.spec.ts`)